### PR TITLE
Update requirements to use fixed mpstool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cycler==0.10.0
 decorator==4.4.1
 defusedxml==0.6.0
 entrypoints==0.3
+imageio==2.6.1
 importlib-metadata==1.4.0
 ipykernel==5.1.3
 ipython==7.9.0
@@ -22,16 +23,17 @@ MarkupSafe==1.1.1
 matplotlib==3.0.3
 mistune==0.8.4
 more-itertools==8.1.0
--e git+https://github.com/UniNE-CHYN/mps_toolbox.git@d6660cc6095aecc45d7521963e45e8b72802bf63#egg=mpstool
+-e git+https://github.com/UniNE-CHYN/mps_toolbox.git@e1383bbfcb8d8298ed2485cacb2c6315019415e3#egg=mpstool
 nbconvert==5.6.1
 nbformat==5.0.3
+networkx==2.4
 notebook==6.0.2
 numpy==1.18.1
 pandocfilters==1.4.2
 parso==0.5.2
 pexpect==4.7.0
 pickleshare==0.7.5
-pkg-resources==0.0.0
+Pillow==7.0.0
 prometheus-client==0.7.1
 prompt-toolkit==2.0.10
 ptyprocess==0.6.0
@@ -39,8 +41,11 @@ Pygments==2.5.2
 pyparsing==2.4.6
 pyrsistent==0.15.7
 python-dateutil==2.8.1
+PyWavelets==1.1.1
 pyzmq==18.1.1
 qtconsole==4.6.0
+scikit-image==0.16.2
+scipy==1.4.1
 Send2Trash==1.5.0
 six==1.13.0
 terminado==0.8.3


### PR DESCRIPTION
Updates requirements.txt:

- removes pkg-resources which come from a bug in debian/ubuntu:
(see: https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command)
- add a newer version of mpstool with correct packaging
- adds mpstool dependencies (generated correctly by pip freeze)